### PR TITLE
Fix invalid test case

### DIFF
--- a/list_test.go
+++ b/list_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestList_Insert(t *testing.T) {
 	list := List{"hoge", "hage"}
-	err := list.Insert(3, "hi")
+	err := list.Insert(2, "hi")
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
list length is 2, so you can't insert index 3 before insert index 2.